### PR TITLE
ps -h causes issues on older systems

### DIFF
--- a/utils/scripts/inotify-consumers
+++ b/utils/scripts/inotify-consumers
@@ -69,6 +69,6 @@ IFS=''; # to avoid `read` from interpreting whitespace and keep whole lines
 generateRawData | while read line; do
     watcher_count=$(echo $line | sed -e 's/.*://')
     pid=$(echo $line | sed -e 's/\/proc\/\([0-9]*\)\/.*/\1/')
-    cmdline=$(ps --columns 120 -o command -h -p $pid) 
+    cmdline=$(ps --columns 120 -o command --no-headers -p $pid) 
     printf "%8d  %7d  %s\n" "$watcher_count" "$pid" "$cmdline"
 done


### PR DESCRIPTION
This script was really handy while working through a resource exhaustion issue I had recently, however, it wouldn't run on the (older) machine where I needed it.

The error I received was 
```
warning: bad ps syntax, perhaps a bogus '-'?
See http://gitorious.org/procps/procps/blobs/master/Documentation/FAQ
```
I found that the ngpcops-ng's `ps` added support for `-h` as an alias for `--no-headers` sometime between versions 3.3.3 (which my ancient disgruntled appliance has on it) and 3.3.10 (the second oldest build I have on hand). The `ps` manpage adds some color around the option:
```
The h option is problematic.  Standard BSD ps uses this option to print a header on each page of output, but older Linux ps uses this option to totally disable the header.
```

Anyway, this change makes your script more able to support older systems and maintains functionality up to the current `ps` release.