### PR TITLE
Added the watchers total count

### DIFF
--- a/utils/scripts/inotify-consumers
+++ b/utils/scripts/inotify-consumers
@@ -66,9 +66,13 @@ printf "%10s  %5s     %s\n" " COUNT " "PID" "CMD"
 printf -- "----------------------------------------\n"
 
 IFS=''; # to avoid `read` from interpreting whitespace and keep whole lines
-generateRawData | while read line; do
+total_watchers=0
+generateRawData | { while read line; do
     watcher_count=$(echo $line | sed -e 's/.*://')
+    total_watchers=$((total_watchers+watcher_count))
     pid=$(echo $line | sed -e 's/\/proc\/\([0-9]*\)\/.*/\1/')
     cmdline=$(ps --columns 120 -o command --no-headers -p $pid) 
     printf "%8d  %7d  %s\n" "$watcher_count" "$pid" "$cmdline"
 done
+printf "\n%8d     %s\n" "$total_watchers" "WATCHERS TOTAL COUNT"
+}


### PR DESCRIPTION
Hello,
i found this script in a stackexchange answer and as [asked by a user](https://unix.stackexchange.com/questions/498393/how-to-get-the-number-of-inotify-watches-in-use#comment968388_502359) it was useful to me add the total of watchers count.

I made a small change to add up all the watchers counts, but i'm not sure if it's the best way to do it, i'm not very familiar with the shell scripts.
