### PR TITLE
Rename "qr-filetransfer" to "qrcp"

### DIFF
--- a/per-host-config/ubuntu/setup.sh
+++ b/per-host-config/ubuntu/setup.sh
@@ -168,7 +168,7 @@ if ! sh -c "mvn --version  | grep '$MAVEN_VERSION' > /dev/null"; then
 fi
 
 blue "Install QR copier\n"
-go get github.com/claudiodangelis/qr-filetransfer
+go get github.com/claudiodangelis/qrcp
 
 # These bits do not make sense on WSL2 (Windows Subsyste for Linux)
 if ! is_wsl; then


### PR DESCRIPTION
Hello, **qr-filetransfer** is simply called **qrcp** now! I'm really glad to see my little tool is part of default setup, cheers! :beers: 

Claudio