### PR TITLE
Added Instance Counts and Per-User Instance stats for fs.inotify.max_user_instances

### DIFF
--- a/utils/scripts/inotify-consumers
+++ b/utils/scripts/inotify-consumers
@@ -54,19 +54,25 @@ generateData(){
     local -i TOT
     local -i TOTINSTANCES
     # read process list into cache
-    local PSLIST="$(ps ax -o pid,user,command --columns $(( COLS - WLEN )))"
-    IFS=","
-    find /proc/*/fd -lname anon_inode:inotify 2> /dev/null |
-        cut -d "/" -f 3 |                # get list of processes
-        uniq |
+    local PSLIST="$(ps ax -o pid,user=WIDE-COLUMN,command --columns $(( COLS - WLEN )))"
+    local INOTIFY="$(find /proc/[0-9]*/fdinfo -type f 2>/dev/null | xargs grep ^inotify 2>/dev/null)"
+    local INOTIFYCNT="$(echo "$INOTIFY" | cut -d "/" -s --output-delimiter=" "  -f 3 |uniq -c | sed -e 's/:.*//')"
+    # unique instances per process is denoted by number of inotify FDs
+    local INOTIFYINSTANCES="$(echo "$INOTIFY" | cut -d "/" -s --output-delimiter=" "   -f 3,5 | sed -e 's/:.*//'| uniq |awk '{print $1}' |uniq -c)"
+    local INOTIFYUSERINSTANCES="$(echo "$INOTIFY" | cut -d "/" -s --output-delimiter=" "   -f 3,5 | sed -e 's/:.*//' | uniq |
+    	     while read PID FD; do echo $PID $FD $(grep -e "^\ *${PID}\ " <<< "$PSLIST"|awk '{print $2}'); done | cut -d" "  -f 3 | sort | uniq -c |sort -nr)"
+    set -e
+
+    cat <<< "$INOTIFYCNT" |
         {
-            while read -rs PROC; do      # count watches of processes found
-                echo "${PROC},$(grep -c "^inotify" < <(cat /proc/${PROC}/fdinfo/* 2> /dev/null)),$(grep -l "^inotify" /proc/${PROC}/fdinfo/* 2>/dev/null | wc -l)"
+            while read -rs CNT PROC; do   # count watches of processes found
+                echo "${PROC},${CNT},$(echo "$INOTIFYINSTANCES" | grep " ${PROC}$" |awk '{print $1}')"
             done
         } |
         grep -v ",0," |                  # remove entires without watches
         sort -n -t "," -k 2,3 -r |         # sort to begin with highest numbers
         {                                # group commands so that $TOT is visible in the printf
+	    IFS=","
             while read -rs PID CNT INSTANCES; do   # show watches and corresponding process info
                 printf "%$(( WLEN - 2 ))d  %$(( WLEN - 2 ))d     %s\n" "$CNT" "$INSTANCES" "$(grep -e "^\ *${PID}\ " <<< "$PSLIST")"
                 TOT=$(( TOT + CNT ))
@@ -74,12 +80,18 @@ generateData(){
             done
 	    # These stats should be per-user as well, since inotify limits are per-user..
             printf "\n%$(( WLEN - 2 ))d  %s\n" "$TOT" "WATCHES TOTAL COUNT"
-            printf "\n%$(( WLEN - 2 ))d  %s\n" "$TOTINSTANCES" "TOTAL INSTANCES COUNT"
+# the total across different users is somewhat meaningless, not printing for now.
+#            printf "\n%$(( WLEN - 2 ))d  %s\n" "$TOTINSTANCES" "TOTAL INSTANCES COUNT"
         }
     echo ""
-    (echo "INSTANCES    USER"
-     readlink -f /proc/*/fd/* |grep '^/proc/.*inotify' |cut -d/ -f3 | xargs -I '{}' -- ps --no-headers -o '%U' -p '{}'| sort | uniq -c|sort -nr) \
-    | column -t |sed -e 's/^/     /'
+    echo "INotify instances per user (e.g. limits specified by fs.inotify.max_user_instances): "
+    echo ""
+    (
+      echo "INSTANCES    USER"
+      echo "-----------  ------------------"
+      echo "$INOTIFYUSERINSTANCES"
+    ) | column -t
+    echo ""
 
 }
 
@@ -88,10 +100,10 @@ generateData(){
 declare -i COLS=$(tput cols 2>/dev/null || echo 80)
 declare -i WLEN=10
 
-printf "\n%${WLEN}s\n" "INOTIFY"
-printf "%${WLEN}s\n" "WATCHES"
-printf "%${WLEN}s  %${WLEN}s  %s\n" " COUNT " "INSTANCES"    "PID USER     COMMAND"
-printf -- "----------------------------------------------------\n"
+printf "\n%${WLEN}s  %${WLEN}s\n" "INOTIFY" "INSTANCES"
+printf "%${WLEN}s  %${WLEN}s\n" "WATCHES" "PER   "
+printf "%${WLEN}s  %${WLEN}s  %s\n" " COUNT " "PROCESS "    "PID USER         COMMAND"
+printf -- "------------------------------------------------------------\n"
 generateData
 
 # not fully implemented with command line switch, so just a executable note:

--- a/utils/scripts/inotify-consumers
+++ b/utils/scripts/inotify-consumers
@@ -50,7 +50,9 @@ generateData(){
     local -i PROC
     local -i PID
     local -i CNT
+    local -i INSTANCES
     local -i TOT
+    local -i TOTINSTANCES
     # read process list into cache
     local PSLIST="$(ps ax -o pid,user,command --columns $(( COLS - WLEN )))"
     IFS=","
@@ -59,37 +61,46 @@ generateData(){
         uniq |
         {
             while read -rs PROC; do      # count watches of processes found
-                echo "${PROC},$(grep -c "^inotify" < <(cat /proc/${PROC}/fdinfo/* 2> /dev/null))"
+                echo "${PROC},$(grep -c "^inotify" < <(cat /proc/${PROC}/fdinfo/* 2> /dev/null)),$(grep -l "^inotify" /proc/${PROC}/fdinfo/* 2>/dev/null | wc -l)"
             done
         } |
-        grep -v ",0$" |                  # remove entires without watches
-        sort -n -t "," -k 2 -r |         # sort to begin with highest numbers
+        grep -v ",0," |                  # remove entires without watches
+        sort -n -t "," -k 2,3 -r |         # sort to begin with highest numbers
         {                                # group commands so that $TOT is visible in the printf
-            while read -rs PID CNT; do   # show watches and corresponding process info
-                printf "%$(( WLEN - 2 ))d  %s\n" "$CNT" "$(grep -e "^\ *${PID}\ " <<< "$PSLIST")"
+            while read -rs PID CNT INSTANCES; do   # show watches and corresponding process info
+                printf "%$(( WLEN - 2 ))d  %$(( WLEN - 2 ))d     %s\n" "$CNT" "$INSTANCES" "$(grep -e "^\ *${PID}\ " <<< "$PSLIST")"
                 TOT=$(( TOT + CNT ))
+		TOTINSTANCES=$(( TOTINSTANCES + INSTANCES))
             done
+	    # These stats should be per-user as well, since inotify limits are per-user..
             printf "\n%$(( WLEN - 2 ))d  %s\n" "$TOT" "WATCHES TOTAL COUNT"
+            printf "\n%$(( WLEN - 2 ))d  %s\n" "$TOTINSTANCES" "TOTAL INSTANCES COUNT"
         }
+    echo ""
+    (echo "INSTANCES    USER"
+     readlink -f /proc/*/fd/* |grep '^/proc/.*inotify' |cut -d/ -f3 | xargs -I '{}' -- ps --no-headers -o '%U' -p '{}'| sort | uniq -c|sort -nr) \
+    | column -t |sed -e 's/^/     /'
+
 }
 
 
 # get terminal width
-declare -i COLS=$(tput cols)
+declare -i COLS=$(tput cols 2>/dev/null || echo 80)
 declare -i WLEN=10
 
 printf "\n%${WLEN}s\n" "INOTIFY"
 printf "%${WLEN}s\n" "WATCHES"
-printf "%${WLEN}s    %s\n" " COUNT " "PID USER     COMMAND"
-printf -- "--------------------------------------\n"
+printf "%${WLEN}s  %${WLEN}s  %s\n" " COUNT " "INSTANCES"    "PID USER     COMMAND"
+printf -- "----------------------------------------------------\n"
 generateData
 
 # not fully implemented with command line switch, so just a executable note:
 # print the # of instances (not watches)
 if [ -n "$PRINT_INSTANCES" ]; then
     FIL=$(mktemp)
-    for foo in /proc/\*/fd/*; do readlink -f $foo; done |grep '^/proc/.*inotify' |cut -d/ -f3 | xargs -I '{}' -- ps --no-headers -o '%p %U %a' -p '{}' |uniq -c |sort -n > $FIL
+    readlink -f /proc/*/fd/* |grep '^/proc/.*inotify' |cut -d/ -f3 | xargs -I '{}' -- ps --no-headers -o '%p %U %a' -p '{}' |uniq -c |sort -n > $FIL
     cat $FIL 
-    cat "TOTAL = $(total=0 cat ut | cut -f7 -d' ' | { while read num; do let total+=$num; done; echo $total; })"
+    echo "TOTAL = $(total=0 cat $FIL | awk '{print $1}' | { while read num; do let total+=$num; done; echo $total; })"
+    rm $FIL
 fi
 


### PR DESCRIPTION
Just a quick extension of your script to have instance stats, since this is useful to know when fs.inotify.max_user_instances limits are being hit.

Cheers!

The per-user stats are slightly off from the TOTAL INSTANCE COUNT, but I think that's due to the fact the script is counting its own sub processes, alternatively I suppose it could use the data it already collected to count each user's total.