### PR TITLE
add --full option

### DIFF
--- a/utils/scripts/inotify-consumers
+++ b/utils/scripts/inotify-consumers
@@ -12,10 +12,6 @@
 # See this for details: https://github.com/fatso83/dotfiles/pull/10#issuecomment-1122374716
 
 main(){
-    # get terminal width
-    declare -i COLS=$(tput cols 2>/dev/null || echo 80)
-    declare -i WLEN=10
-
     printf "\n%${WLEN}s  %${WLEN}s\n" "INOTIFY" "INSTANCES"
     printf "%${WLEN}s  %${WLEN}s\n" "WATCHES" "PER   "
     printf "%${WLEN}s  %${WLEN}s  %s\n" " COUNT " "PROCESS "    "PID USER         COMMAND"
@@ -26,15 +22,11 @@ main(){
 usage(){
     cat << EOF
 Usage: $0 [--help|--limits]
-
     -l, --limits    Will print the current related limits and how to change them
     -h, --help      Show this help
-
 FYI:  Check out Michael Sartain's C++ take on this script. The native executable 
       is much faster, modern and feature rich. It can be found at 
-
       https://github.com/mikesart/inotify-info
-
 EOF
 }
 
@@ -43,33 +35,14 @@ limits(){
     sysctl fs.inotify.max_user_instances fs.inotify.max_user_watches
 
     cat <<- EOF
-
-
 Changing settings permanently
 -----------------------------
 echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf
 sudo sysctl -p # re-read config
-
 EOF
 }
 
-if [ "$1" = "--limits" -o "$1" = "-l" ]; then
-    limits
-    exit 0
-fi
-
-if [ "$1" = "--help" -o "$1" = "-h" ]; then
-    usage 
-    exit 0
-fi
-
-if [ -n "$1" ]; then
-    printf "\nUnknown parameter '$1'\n" >&2
-    usage
-    exit 1
-fi
-
-generateData(){
+generateData() {
     local -i PROC
     local -i PID
     local -i CNT
@@ -77,7 +50,7 @@ generateData(){
     local -i TOT
     local -i TOTINSTANCES
     # read process list into cache
-    local PSLIST="$(ps ax -o pid,user=WIDE-COLUMN,command --columns $(( COLS - WLEN )))"
+    local PSLIST="$(ps ax -o pid,user=WIDE-COLUMN,command $COLSTRING)"
     local INOTIFY="$(find /proc/[0-9]*/fdinfo -type f 2>/dev/null | xargs grep ^inotify 2>/dev/null)"
     local INOTIFYCNT="$(echo "$INOTIFY" | cut -d "/" -s --output-delimiter=" "  -f 3 |uniq -c | sed -e 's/:.*//')"
     # unique instances per process is denoted by number of inotify FDs
@@ -115,7 +88,33 @@ generateData(){
       echo "$INOTIFYUSERINSTANCES"
     ) | column -t
     echo ""
-
+    exit 0
 }
 
+# get terminal width
+declare -i COLS=$(tput cols 2>/dev/null || echo 80)
+declare -i WLEN=10
+declare COLSTRING="--columns $(( COLS - WLEN ))" # get terminal width
+
+if [ "$1" = "--limits" -o "$1" = "-l" ]; then
+    limits
+    exit 0
+fi
+
+if [ "$1" = "--help" -o "$1" = "-h" ]; then
+    usage
+    exit 0
+fi
+
+# added this line and moved some declarations to allow for the full display instead of a truncated version
+if [ "$1" = "--full" -o "$1" = "-f" ]; then
+    unset COLSTRING
+    main
+fi
+
+if [ -n "$1" ]; then
+    printf "\nUnknown parameter '$1'\n" >&2
+    usage
+    exit 1
+fi
 main


### PR DESCRIPTION
I'm not particularly well versed in shell coding, however I made a change to your script to allow it to display the full command instead of truncating it. I thought I'd share it in case you found it useful also.
The declarations from the main() function have been moved to the bottom of the file, as have the conditionals for the command line args.
I added an extra declaration for COLSTRING that is unset if the user chooses the full output. 
Let me know if you have any questions.