### PR TITLE
Update for grep 3.8 compatibility

### DIFF
--- a/utils/scripts/inotify-consumers
+++ b/utils/scripts/inotify-consumers
@@ -56,7 +56,7 @@ generateData() {
     # unique instances per process is denoted by number of inotify FDs
     local INOTIFYINSTANCES="$(echo "$INOTIFY" | cut -d "/" -s --output-delimiter=" "   -f 3,5 | sed -e 's/:.*//'| uniq |awk '{print $1}' |uniq -c)"
     local INOTIFYUSERINSTANCES="$(echo "$INOTIFY" | cut -d "/" -s --output-delimiter=" "   -f 3,5 | sed -e 's/:.*//' | uniq |
-    	     while read PID FD; do echo $PID $FD $(grep -e "^\ *${PID}\ " <<< "$PSLIST"|awk '{print $2}'); done | cut -d" "  -f 3 | sort | uniq -c |sort -nr)"
+    	     while read PID FD; do echo $PID $FD $(grep -e "^ *${PID} " <<< "$PSLIST"|awk '{print $2}'); done | cut -d" "  -f 3 | sort | uniq -c |sort -nr)"
     set -e
 
     cat <<< "$INOTIFYCNT" |
@@ -70,7 +70,7 @@ generateData() {
         {                                # group commands so that $TOT is visible in the printf
 	    IFS=","
             while read -rs PID CNT INSTANCES; do   # show watches and corresponding process info
-                printf "%$(( WLEN - 2 ))d  %$(( WLEN - 2 ))d     %s\n" "$CNT" "$INSTANCES" "$(grep -e "^\ *${PID}\ " <<< "$PSLIST")"
+                printf "%$(( WLEN - 2 ))d  %$(( WLEN - 2 ))d     %s\n" "$CNT" "$INSTANCES" "$(grep -e "^ *${PID} " <<< "$PSLIST")"
                 TOT=$(( TOT + CNT ))
 		TOTINSTANCES=$(( TOTINSTANCES + INSTANCES))
             done


### PR DESCRIPTION
GNU grep 3.8 no longer treats backslashes the same as older versions of grep. Something about it being "undefined behavior" according to POSIX. The NEWS file in the GNU grep 3.8 source code has:
> Regular expressions with stray backslashes now cause warnings, as
> their unspecified behavior can lead to unexpected results.
> For example, '\a' and 'a' are not always equivalent
> <https://bugs.gnu.org/39678>.

That change to GNU grep breaks your inotify-consumers script.  Try it and see. I took out the backslashes and it appears to be OK.  I'm not sure why backslashes were being used at all in the first place as they have "undefined behavior" according to POSIX.