### PR TITLE
Change shebang to `/usr/bin/env bash`

### DIFF
--- a/utils/scripts/inotify-consumers
+++ b/utils/scripts/inotify-consumers
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the procs sorted by the number of inotify watches
 # @author Carl-Erik Kopseng


### PR DESCRIPTION
This makes it compatible with systems where bash is installed in a different location.

some details: https://askubuntu.com/a/1402721